### PR TITLE
Return status code 404 if job does not exist

### DIFF
--- a/dkron/api.go
+++ b/dkron/api.go
@@ -133,6 +133,10 @@ func (a *AgentCommand) jobGetHandler(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.Error(err)
 	}
+	if job == nil {
+		w.WriteHeader(http.StatusNotFound)
+		return
+	}
 
 	if err := printJson(w, r, job); err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
When trying to fetch a job via `GET /v1/jobs/<name>`, dkron should
respond with HTTP 404.